### PR TITLE
impl Default for mock objects

### DIFF
--- a/simulacrum_macros/src/lib.rs
+++ b/simulacrum_macros/src/lib.rs
@@ -155,6 +155,12 @@ macro_rules! create_mock_struct {
 
             create_mock_struct!(@create_expect_methods $($methods)*);
         }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
     };
 }
 

--- a/simulacrum_mock/src/mock.rs
+++ b/simulacrum_mock/src/mock.rs
@@ -5,6 +5,7 @@ use std::thread;
 use super::method::Method;
 use super::store::ExpectationStore;
 
+#[derive(Default)]
 pub struct Expectations {
     store: ExpectationStore
 }

--- a/simulacrum_mock/src/store.rs
+++ b/simulacrum_mock/src/store.rs
@@ -166,6 +166,12 @@ impl ExpectationStore {
     }
 }
 
+impl Default for ExpectationStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // Used internally to mutably access an `ExpectationStore`.
 pub struct ExpectationEditor<'a, I, O> {
     id: ExpectationId,


### PR DESCRIPTION
This allows users to instantiate mock objects as `MockFoo::default()`.  It also pleases Clippy, which frowns upon `new()` methods with no arguments.